### PR TITLE
Validate version format: vX.Y.Z[-xxxx]

### DIFF
--- a/publish-version
+++ b/publish-version
@@ -36,6 +36,10 @@ shift 1
 # Validate args...
 [ -z "$version" -o $# -lt 1 ] && echo "usage: $(dirname $0) <version> <docker-image>..." >&2 && exit 1
 
+# Validate the version format.
+! [[ $version =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9])*$ ]] && \
+  echo "Invalid version format: $version" >&2 && exit 1
+
 # Validate docker logins...
 ! egrep -q '"auths": {$' ~/.docker/config.json && echo "Not logged in to dockerhub!" >&2 && exit 1
 


### PR DESCRIPTION
Allows following version formats:
v1.2.3
v0.12.3
v1.2.3-rc.1
v.1.2.3-alpha.1

In general, the v1.2.3 optional postfix must start with "-" followed by alphanums that can be separated by "."