### PR TITLE
A simple tool for updating Go dependencies on a repo based on tags

### DIFF
--- a/bump-onos-deps.sh
+++ b/bump-onos-deps.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright 2020-present Open Networking Foundation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Poor-man's tool to bump the onosproject dependencies for a project:
+#   1) "go get -u" on the dependencies with the new tag
+#   2) create a branch
+#   3) push to git
+
+# The tool requires the user to have the authorization to:
+#   1) push tag to the upstream repo
+
+# Also, the following conditions must be met:
+#   1) repo must have upstream (or origin) remote push enabled via ssh
+#   2) non-empty version number is specified
+
+version="${1}"
+shift 1
+
+# Validate args...
+[ -z "$version" -o $# -lt 1 ] && echo "usage: $0 <version> <dependencies>..." >&2 && exit 1
+
+# Validate upstream (or origin) push URL is via SSH...
+git remote -v | grep upstream | grep -q push && upstream="upstream" || upstream="origin"
+! git remote -v | grep $upstream | grep push | cut -f2 | cut -d\  -f1 | grep -q 'git@github.com:' && \
+      echo "Upstream remote not setup with SSH push URL" >&2 && exit 1
+
+# Validate we are on master
+! git status -b | grep "On branch" | cut -d\  -f3 | grep -q master && \
+      echo "Not on master branch" >&2 && exit 1
+
+! git status -b | grep -q "nothing to commit, working tree clean" && \
+      echo "There are modified files" >&2 && exit 1
+
+# 1) Run "go get -u"
+for dependency in "$@"; do
+  GO111MODULE=on go get -u github.com/onosproject/$dependency@$version
+done
+GO111MODULE=on go build -v ./...
+
+# 2) Create a branch and push it
+git checkout -b onosdeps$version && \
+git add go.mod go.sum && \
+git commit -m"Bump to $version of onosproject dependencies" && \
+git push upstream


### PR DESCRIPTION
This should be run like (for example from onos-topo)

```
../build-tools/bump-onos-deps.sh v0.6.0 onos-lib-go helmit
```

See https://github.com/onosproject/onos-topo/pull/109 for an example of what the output is like

There would need to be some super script above this one to enforce a definite order.
```
1. onos-lib-go: publish-version v0.6.0

2. helmit: 		publish-version v0.6.0 onosproject/helmit-runner onosproject/helmit-tests

3. onos-topo:		bump-onos-deps.sh v0.6.0 onos-lib-go helmit

4. onos-topo:		publish-version v0.6.0 onosproject/onos-topo

5. onos-ric:    	bump-onos-deps.sh v0.6.0 onos-lib-go helmit onos-topo

6. onos-ric:		publish-version v0.6.0 onosproject/onos-ric onosproject/onos-ric-ho onosproject/onos-ric-mlb

7. ran-simulator:	bump-onos-deps.sh v0.6.0 onos-lib-go onos-topo onos-ric

8. ran-simulator:	publish-version v0.6.0 onosproject/ran-simulator

9. config-models:	publish-version v0.6.0 onosproject/config-model-testdevice-1.0.0 onosproject/config-model-testdevice-2.0.0 onosproject/config-model-devicesim-1.0.0 onosproject/config-model-stratum-1.0.0

10. onos-config		bump-onos-deps.sh v0.6.0 onos-lib-go helmit onos-topo config-models/modelplugin/testdevice-1.0.0 config-models/modelplugin/testdevice-2.0.0 config-models/modelplugin/devicesim-1.0.0

11. onos-config:	publish-version v0.6.0 onosproject/onos-config

12. onos-ztp		bump-onos-deps.sh v0.6.0 onos-lib-go onos-config onos-topo

13. onos-ztp		publish-version v0.6.0 onosproject/onos-ztp

14. onos-cli            bump-onos-deps.sh v0.6.0 onos-lib-go onos-config onos-topo onos-ztp onos-ric ran-simulator

15. onos-cli            publish-version v0.6.0 onosproject/onos-cli

16. onos-helm-charts    bump-onos-deps.sh v0.6.0 helmit

17. onos-helm-charts	publish-version v0.6.0

18. onos-docs		publish-version v0.6.0 onosproject/onos-docs

19. onos-gui		publish-version v0.6.0 onosproject/onos-gui

20. gnxi-simulators	publish-version v0.6.0 onosproject/device-simulator

21. netconf-simulator   publish-version v0.6.0 onosproject/netconf-simulator

22. gnmi-netconf-adapter publish-version v0.6.0 onosproject/gnmi-netconf-adapter
```