### PR TITLE
If already inside a triggered job, don't trigger any children

### DIFF
--- a/build/travis/trigger-travis
+++ b/build/travis/trigger-travis
@@ -6,6 +6,12 @@ if [ "$#" -ne 5 ]; then
   exit 1
 fi
 
+trigger=${TRAVIS_JOB_NAME%% *}
+if [ $trigger = "Triggered" ]; then
+  # This is a triggered job, don't make any children
+  exit 0
+fi
+
 PROJECT=$1
 REPO=$2
 BRANCH=$3


### PR DESCRIPTION
If already inside a triggered job, don't trigger any children. Prevents triggered onos-cli jobs from triggering test jobs again