### PR TITLE
Expand protoc builder deps to include google common and p4runtime

### DIFF
--- a/build/protoc-go/Dockerfile
+++ b/build/protoc-go/Dockerfile
@@ -1,14 +1,15 @@
-FROM golang:1.14
+FROM golang:1.15
 
 RUN apt-get update && \
     apt-get install -y unzip python3 python3-pip
 
-RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protoc-3.13.0-linux-x86_64.zip && \
-    unzip -o protoc-3.13.0-linux-x86_64.zip -d /usr/local bin/protoc && \
-    unzip -o protoc-3.13.0-linux-x86_64.zip -d /usr/local include/* && \
-    rm -rf protoc-3.13.0-linux-x86_64.zip
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip && \
+    unzip -o protoc-3.15.8-linux-x86_64.zip -d /usr/local bin/protoc && \
+    unzip -o protoc-3.15.8-linux-x86_64.zip -d /usr/local include/* && \
+    rm -rf protoc-3.15.8-linux-x86_64.zip
 
-RUN go get -u github.com/golang/protobuf/protoc-gen-go && \
+RUN go get -u google.golang.org/protobuf/cmd/protoc-gen-go && \
+    go get -u google.golang.org/grpc/cmd/protoc-gen-go-grpc && \
     go get -u github.com/gogo/protobuf/proto && \
     go get -u github.com/gogo/protobuf/gogoproto && \
     go get -u github.com/gogo/protobuf/protoc-gen-gofast && \
@@ -20,12 +21,14 @@ RUN go get -u github.com/golang/protobuf/protoc-gen-go && \
     go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway && \
     go get -u github.com/envoyproxy/protoc-gen-validate
 
-RUN mkdir -p /go/src/github.com/google && \
+RUN mkdir -p /go/src/github.com/google /go/src/github.com/p4lang && \
     git clone --branch master https://github.com/google/protobuf /go/src/github.com/google/protobuf && \
     git clone --branch master https://github.com/openconfig/gnmi /go/src/github.com/openconfig/gnmi && \
+    git clone --branch main https://github.com/p4lang/p4runtime /go/src/github.com/p4lang/p4runtime && \
+    git clone --branch master https://github.com/googleapis/api-common-protos /go/src/github.com/googleapis/api-common-protos && \
     mkdir -p /go/src/github.com/ &&\
-    wget "https://github.com/grpc/grpc-web/releases/download/1.0.7/protoc-gen-grpc-web-1.0.7-linux-x86_64" --quiet && \
-    mv protoc-gen-grpc-web-1.0.7-linux-x86_64 /usr/local/bin/protoc-gen-grpc-web && \
+    wget "https://github.com/grpc/grpc-web/releases/download/1.2.1/protoc-gen-grpc-web-1.2.1-linux-x86_64" --quiet && \
+    mv protoc-gen-grpc-web-1.2.1-linux-x86_64 /usr/local/bin/protoc-gen-grpc-web && \
     chmod +x /usr/local/bin/protoc-gen-grpc-web
 
 RUN pip3 install --pre "betterproto[compiler]"


### PR DESCRIPTION
Working through api definitions for onos-control and found that the google [common types](https://github.com/googleapis/api-common-protos) not included. Additionally in an attempt to reuse p4lang/p4runtime resource definitions added this path to the builder container as well.

Not sure if this is the right approach but opening in hopes to glean some insight on what "should" do 👍 

api defs PR https://github.com/onosproject/onos-api/pull/81