### PR TITLE
Allow tag-collision-reject to check for custom tags not specified in any version file

### DIFF
--- a/tag-collision-reject
+++ b/tag-collision-reject
@@ -21,7 +21,7 @@
 set -eu -o pipefail
 
 VERSIONFILE=${VERSIONFILE:-VERSION} # file path to file containing version number
-NEW_VERSION="" # version number found in $VERSIONFILE
+NEW_VERSION=${NEW_VERSION:-""} # if not set version number found in $VERSIONFILE, otherwise custom version number (if used it is always checked agains git_tag)
 TAG_VERSION="" # version file that might have a leading v to work around go mod funkyness
 
 SEMVER_STRICT=${SEMVER_STRICT:-0} # require semver versions
@@ -35,7 +35,14 @@ WORKSPACE=${WORKSPACE:-.}
 # find the version string in the repo, read into NEW_VERSION
 # Add additional places NEW_VERSION could be found to this function
 function read_version {
-  if [ -f "$VERSIONFILE" ]
+  if [[ $NEW_VERSION != "" ]]
+  then
+    # this means the script is used to check a custom version,
+    # do not read in any files but always check against git tags
+    releaseversion=1
+    fail_validation=1
+    TAG_VERSION=${NEW_VERSION}
+  elif [ -f "$VERSIONFILE" ]
   then
     NEW_VERSION=$(head -n1 "$VERSIONFILE")
 
@@ -59,7 +66,7 @@ function read_version {
     TAG_VERSION=$NEW_VERSION
     VERSIONFILE="pom.xml"
   else
-    echo "ERROR: No versioning file found!"
+    echo "ERROR: No versioning file found! At ${VERSIONFILE}"
     exit 1
   fi
 }
@@ -83,7 +90,7 @@ function check_if_releaseversion {
 
 # check if the version is already a tag in git
 function is_git_tag_duplicated {
-  for existing_tag in $(git tag)
+  for existing_tag in $(git tag | cat)
   do
     if [ "$TAG_VERSION" = "$existing_tag" ]
     then
@@ -154,7 +161,7 @@ echo "Branches:"
 git branch -v
 
 echo "Existing git tags:"
-git tag -n
+git tag -n | cat
 
 read_version
 check_if_releaseversion


### PR DESCRIPTION
This is needed to check if a git tag for the config models has already been pushed to git.